### PR TITLE
fix: compiler warning due to implicit `HTTP::Client::Response#body?` type

### DIFF
--- a/src/core_ext/http/client/response.cr
+++ b/src/core_ext/http/client/response.cr
@@ -1,0 +1,9 @@
+# Provide an explicit return type (missing from stb-lib) to prevent the compiler
+# warning when injecting `Responsible::ResponseInterface`.
+
+# :nodoc:
+class HTTP::Client::Response
+  def body? : String?
+    previous_def
+  end
+end

--- a/src/responsible.cr
+++ b/src/responsible.cr
@@ -72,4 +72,5 @@ module Responsible
   end
 end
 
+require "./core_ext/http/client/response"
 Responsible.support HTTP::Client::Response


### PR DESCRIPTION
Overrides base `HTTP::Client::Response#body?` signature to provide an explicit return type.